### PR TITLE
Add capability to vault single value

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+[*.lua]
+indent_style = space
+indent_size = 2

--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,3 @@
+syntax = "All"
+indent_type = Spaces
+indent_width = 2

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A Neovim plugin for handling Ansible vault encrypted files.
 - Maintains encryption when saving files
 - Supports custom vault password file patterns
 - Integrates with Ansible vault commands
+- Encrypt or decrypt single yaml value with command `AnsibleToggleVaultLine`
 
 ## Installation
 
@@ -54,11 +55,21 @@ Default configuration:
 
 ## Usage
 
+### Whole file encryption
+
 1. Place your vault password in a `.vault_pass` or `.vault-pass` file in your project directory
 2. Open an encrypted vault file
 3. The plugin will automatically detect and decrypt the file
 4. Edit the file normally
 5. Save with `:w` to encrypt and save the file
+
+### Value encryption
+
+1. Place your cursor on the line which you want encrypt or decrypt
+2. Run command `AnsibleToggleVaultLine`
+   - Encrypted line will be decrypted and clear value will be encrypted
+
+NOTE: Multiline encryption are not supported
 
 ## Contributing
 

--- a/lua/ansible-vault/init.lua
+++ b/lua/ansible-vault/init.lua
@@ -1,9 +1,11 @@
+local utils = require("ansible-vault.utils")
+
 local M = {}
 
 M.config = {
-  vault_password_files = {'.vault_pass', '.vault-pass'},
-  patterns = {'*/host_vars/*/vault.yml', '*/group_vars/*/vault.yml'},
-  vault_id = 'default'
+  vault_password_files = { ".vault_pass", ".vault-pass" },
+  patterns = { "*/host_vars/*/vault.yml", "*/group_vars/*/vault.yml" },
+  vault_id = "default",
 }
 
 M.encrypted_buffers = {}
@@ -13,67 +15,6 @@ function M.is_vault_file(buf)
   return first_line and first_line:match("^%$ANSIBLE_VAULT;") ~= nil
 end
 
-function M.find_vault_pass_file(path)
-  if not path then return nil end
-
-  local function find_project_root(start_path)
-    local current_dir = vim.fn.fnamemodify(start_path, ':h')
-    while current_dir ~= '/' do
-      if vim.fn.isdirectory(current_dir .. '/.git') == 1 or
-        vim.fn.filereadable(current_dir .. '/ansible.cfg') == 1 then
-        return current_dir
-      end
-      current_dir = vim.fn.fnamemodify(current_dir, ':h')
-    end
-    return nil
-  end
-
-  local project_root = find_project_root(path)
-  if not project_root then
-    return nil
-  end
-
-  local check_locations = {
-    project_root .. '/.vault_pass',
-    project_root .. '/vault_pass',
-    project_root .. '/group_vars/.vault_pass',
-    project_root .. '/group_vars/vault_pass',
-    project_root .. '/ansible.cfg'
-  }
-
-  for _, location in ipairs(check_locations) do
-    if vim.fn.filereadable(location) == 1 then
-      if vim.fn.fnamemodify(location, ':t') == 'ansible.cfg' then
-        local lines = vim.fn.readfile(location)
-        for _, line in ipairs(lines) do
-          local vault_file = line:match("vault_password_file%s*=%s*(.+)")
-          if vault_file then
-            if not vault_file:match("^/") then
-              vault_file = project_root .. '/' .. vault_file
-            end
-            if vim.fn.filereadable(vault_file) == 1 then
-              return vault_file
-            end
-          end
-        end
-      else
-        return location
-      end
-    end
-  end
-
-  if M.config.vault_password_files then
-    for _, file in ipairs(M.config.vault_password_files) do
-      local vault_path = project_root .. '/' .. file
-      if vim.fn.filereadable(vault_path) == 1 then
-        return vault_path
-      end
-    end
-  end
-
-  return nil
-end
-
 function M.save_encrypted_file(buf, force)
   local info = M.encrypted_buffers[buf]
   if not info then
@@ -81,7 +22,7 @@ function M.save_encrypted_file(buf, force)
     return false
   end
 
-  if not force and not vim.api.nvim_buf_get_option(buf, 'modified') then
+  if not force and not vim.api.nvim_buf_get_option(buf, "modified") then
     vim.notify("No changes to save", vim.log.levels.INFO)
     return true
   end
@@ -91,15 +32,18 @@ function M.save_encrypted_file(buf, force)
   vim.fn.writefile(lines, tmp)
 
   local encrypt_cmd = string.format(
-    'ansible-vault encrypt --vault-id %s@%s --encrypt-vault-id %s %s',
-    M.config.vault_id, info.password_file, M.config.vault_id, tmp
+    "ansible-vault encrypt --vault-id %s@%s --encrypt-vault-id %s %s",
+    M.config.vault_id,
+    info.password_file,
+    M.config.vault_id,
+    tmp
   )
   local result = vim.fn.system(encrypt_cmd)
 
   if vim.v.shell_error == 0 then
-    vim.fn.system(string.format('mv %s %s', tmp, info.file_path))
+    vim.fn.system(string.format("mv %s %s", tmp, info.file_path))
     vim.notify("File encrypted and saved", vim.log.levels.INFO)
-    vim.api.nvim_buf_set_option(buf, 'modified', false)
+    vim.api.nvim_buf_set_option(buf, "modified", false)
     return true
   else
     vim.notify("Failed to encrypt file: " .. result, vim.log.levels.ERROR)
@@ -117,17 +61,17 @@ end
 function M.setup_buffer(buf, file_path, password_file)
   M.encrypted_buffers[buf] = {
     file_path = file_path,
-    password_file = password_file
+    password_file = password_file,
   }
 
-  vim.api.nvim_buf_set_option(buf, 'buftype', 'acwrite')
-  vim.api.nvim_buf_set_option(buf, 'modifiable', true)
+  vim.api.nvim_buf_set_option(buf, "buftype", "acwrite")
+  vim.api.nvim_buf_set_option(buf, "modifiable", true)
 
-  local augroup = vim.api.nvim_create_augroup('AnsibleVaultBuffer' .. buf, { clear = true })
+  local augroup = vim.api.nvim_create_augroup("AnsibleVaultBuffer" .. buf, { clear = true })
 
-  vim.api.nvim_buf_create_user_command(buf, 'Write', function(opts)
+  vim.api.nvim_buf_create_user_command(buf, "Write", function(opts)
     M.handle_write_cmd(opts)
-  end, {bang = true, desc = 'Save encrypted vault file'})
+  end, { bang = true, desc = "Save encrypted vault file" })
 
   vim.api.nvim_create_autocmd("BufLeave", {
     group = augroup,
@@ -138,15 +82,15 @@ function M.setup_buffer(buf, file_path, password_file)
           vim.api.nvim_buf_delete(buf, { force = true })
         end
       end)
-    end
+    end,
   })
 
-  vim.api.nvim_create_autocmd({"BufWriteCmd", "FileWriteCmd"}, {
+  vim.api.nvim_create_autocmd({ "BufWriteCmd", "FileWriteCmd" }, {
     group = augroup,
     buffer = buf,
     callback = function()
       return M.handle_write_cmd({})
-    end
+    end,
   })
 
   vim.api.nvim_create_autocmd("BufDelete", {
@@ -154,19 +98,19 @@ function M.setup_buffer(buf, file_path, password_file)
     buffer = buf,
     callback = function()
       M.encrypted_buffers[buf] = nil
-    end
+    end,
   })
 end
 
 function M.open_with_vault(file_path, password_file)
   local current_buf = vim.api.nvim_get_current_buf()
 
-  local cmd = string.format('ansible-vault view --vault-password-file %s %s', password_file, file_path)
+  local cmd = string.format("ansible-vault view --vault-password-file %s %s", password_file, file_path)
   local content = vim.fn.system(cmd)
 
   if vim.v.shell_error == 0 then
-    local lines = vim.split(content, '\n')
-    if lines[#lines] == '' then
+    local lines = vim.split(content, "\n")
+    if lines[#lines] == "" then
       table.remove(lines)
     end
 
@@ -174,9 +118,9 @@ function M.open_with_vault(file_path, password_file)
 
     M.setup_buffer(current_buf, file_path, password_file)
 
-    vim.api.nvim_buf_set_option(current_buf, 'modified', false)
+    vim.api.nvim_buf_set_option(current_buf, "modified", false)
 
-    vim.api.nvim_buf_set_option(current_buf, 'filetype', 'yaml')
+    vim.api.nvim_buf_set_option(current_buf, "filetype", "yaml")
   else
     vim.notify("Failed to decrypt file: " .. content, vim.log.levels.ERROR)
   end
@@ -191,16 +135,16 @@ function M.handle_vault_file()
       return
     end
 
-    local vault_pass = M.find_vault_pass_file(file_path)
+    local vault_pass = utils.find_vault_pass_file(file_path, M.config.vault_password_files)
     if vault_pass then
       vim.ui.select(
-        {'Yes', 'No'},
-        {prompt = 'This is an Ansible vault file. Open with vault password file?'},
+        { "Yes", "No" },
+        { prompt = "This is an Ansible vault file. Open with vault password file?" },
         function(choice)
-          if choice == 'Yes' then
+          if choice == "Yes" then
             M.open_with_vault(file_path, vault_pass)
           else
-            local augroup = vim.api.nvim_create_augroup('AnsibleVaultDeclined' .. buf, { clear = true })
+            local augroup = vim.api.nvim_create_augroup("AnsibleVaultDeclined" .. buf, { clear = true })
             vim.api.nvim_create_autocmd("BufLeave", {
               group = augroup,
               buffer = buf,
@@ -211,7 +155,7 @@ function M.handle_vault_file()
                   end
                 end)
               end,
-              once = true
+              once = true,
             })
           end
         end
@@ -222,19 +166,111 @@ function M.handle_vault_file()
   end
 end
 
+function M.encrypt_line(current_line_num, yaml_key, line_indent, yaml_value)
+  if utils.is_encrypted_value(yaml_value) then
+    vim.notify("Current value already encrypted", vim.log.levels.WARN)
+    return false
+  elseif utils.is_start_of_value_block(yaml_value) then
+    vim.notify("This plugin does not support multiline encryption", vim.log.levels.WARN)
+    return false
+  end
+  local vault_pass = utils.get_vault_pass_for_current_buffer(M.config.vault_password_files)
+  if not vault_pass then
+    vim.notify("Can not find vault password file for current buffer", vim.log.levels.WARN)
+    return false
+  end
+  local encrypt_string_cmd = string.format(
+    "ansible-vault encrypt_string --vault-id %s@%s --name='%s' '%s'",
+    M.config.vault_id,
+    vault_pass,
+    yaml_key,
+    yaml_value
+  )
+  local result = vim.fn.system(encrypt_string_cmd)
+  if vim.v.shell_error == 0 then
+    vim.api.nvim_del_current_line()
+    local f_indent_line = function(line)
+      return line_indent .. line
+    end
+    local lines_with_indentation = vim.tbl_map(f_indent_line, vim.fn.split(result, "\n"))
+    vim.fn.append(current_line_num - 1, lines_with_indentation)
+    vim.fn.setpos(".", { 0, current_line_num, 0 })
+    return true
+  end
+  vim.notify("Can not encrypt string: " .. result, vim.log.levels.ERROR)
+  return false
+end
+
+function M.decrypt_line(current_line_num, yaml_key, line_indent, yaml_value)
+  if not utils.is_encrypted_value(yaml_value) then
+    vim.notify("Is not encrypted value", vim.log.levels.WARN)
+    return false
+  end
+  local vault_pass = utils.get_vault_pass_for_current_buffer(M.config.vault_password_files)
+  if not vault_pass then
+    vim.notify("Can not find vault password file for current buffer", vim.log.levels.WARN)
+    return false
+  end
+  local yaml_file = vim.fn.expand("%")
+  local encrypt_string_cmd = string.format(
+    "ansible localhost -m ansible.builtin.debug -a var='%s' -e '@%s' --vault-id %s@%s",
+    yaml_key,
+    yaml_file,
+    M.config.vault_id,
+    vault_pass
+  )
+  local result = vim.fn.system(encrypt_string_cmd)
+  if vim.v.shell_error == 0 then
+    vim.api.nvim_del_current_line() -- delete line with !vault
+    vim.api.nvim_del_current_line() -- delete line with $ANSIBLE_VAULT
+    while utils.extract_string_pattern(current_line_num, utils.pattern_hex_line) do
+      vim.api.nvim_del_current_line() -- delete hex line
+    end
+    local raw_decrypted_value = vim.trim(vim.fn.split(result, "\n")[2])
+    -- remove "" from yaml key
+    local decrypted_value = string.gsub(raw_decrypted_value, '%s*"([a-z_]+)":%s+(.*)$', "%1: %2")
+    vim.fn.append(current_line_num - 1, line_indent .. decrypted_value)
+    vim.fn.setpos(".", { 0, current_line_num, 0 })
+    return true
+  end
+  vim.notify("Can not decrypt string: " .. result, vim.log.levels.ERROR)
+  return false
+end
+
+function M.toggle_line_encryption()
+  local current_line_num, yaml_key, line_indent = utils.parse_current_line_to_extract_key_and_indent()
+  if current_line_num == nil or yaml_key == nil then
+    return nil
+  end
+  local yaml_value = utils.get_yaml_value_for_the_line(current_line_num, yaml_key)
+  if not yaml_value then
+    vim.notify("Can not get yaml value for the current line", vim.log.levels.WARN)
+    return false
+  end
+  if utils.is_encrypted_value(yaml_value) then
+    M.decrypt_line(current_line_num, yaml_key, line_indent, yaml_value)
+  else
+    M.encrypt_line(current_line_num, yaml_key, line_indent, yaml_value)
+  end
+end
+
 function M.setup(opts)
   if opts then
     M.config = vim.tbl_deep_extend("force", M.config, opts)
   end
 
-  local augroup = vim.api.nvim_create_augroup('AnsibleVault', { clear = true })
+  local augroup = vim.api.nvim_create_augroup("AnsibleVault", { clear = true })
 
   vim.api.nvim_create_autocmd("BufReadPost", {
     group = augroup,
     pattern = M.config.patterns,
     callback = function()
       M.handle_vault_file()
-    end
+    end,
+  })
+
+  vim.api.nvim_create_user_command("AnsibleToggleVaultLine", M.toggle_line_encryption, {
+    desc = "Toggle encryption in ansible yaml files",
   })
 end
 

--- a/lua/ansible-vault/utils.lua
+++ b/lua/ansible-vault/utils.lua
@@ -5,137 +5,137 @@ M.pattern_sting_indent = "^(%s).*$"
 M.pattern_hex_line = "^%s*([0-9a-f]+)$"
 
 function M.find_vault_pass_file(path, vault_password_files)
-	if not path then
-		return nil
-	end
+  if not path then
+    return nil
+  end
 
-	local function find_project_root(start_path)
-		local current_dir = vim.fn.fnamemodify(start_path, ":h")
-		while current_dir ~= "/" do
-			if
-				vim.fn.isdirectory(current_dir .. "/.git") == 1
-				or vim.fn.filereadable(current_dir .. "/ansible.cfg") == 1
-			then
-				return current_dir
-			end
-			current_dir = vim.fn.fnamemodify(current_dir, ":h")
-		end
-		return nil
-	end
+  local function find_project_root(start_path)
+    local current_dir = vim.fn.fnamemodify(start_path, ":h")
+    while current_dir ~= "/" do
+      if
+        vim.fn.isdirectory(current_dir .. "/.git") == 1
+        or vim.fn.filereadable(current_dir .. "/ansible.cfg") == 1
+      then
+        return current_dir
+      end
+      current_dir = vim.fn.fnamemodify(current_dir, ":h")
+    end
+    return nil
+  end
 
-	local project_root = find_project_root(path)
-	if not project_root then
-		return nil
-	end
+  local project_root = find_project_root(path)
+  if not project_root then
+    return nil
+  end
 
-	local check_locations = {
-		project_root .. "/.vault_pass",
-		project_root .. "/vault_pass",
-		project_root .. "/group_vars/.vault_pass",
-		project_root .. "/group_vars/vault_pass",
-		project_root .. "/ansible.cfg",
-	}
+  local check_locations = {
+    project_root .. "/.vault_pass",
+    project_root .. "/vault_pass",
+    project_root .. "/group_vars/.vault_pass",
+    project_root .. "/group_vars/vault_pass",
+    project_root .. "/ansible.cfg",
+  }
 
-	for _, location in ipairs(check_locations) do
-		if vim.fn.filereadable(location) == 1 then
-			if vim.fn.fnamemodify(location, ":t") == "ansible.cfg" then
-				local lines = vim.fn.readfile(location)
-				for _, line in ipairs(lines) do
-					local vault_file = line:match("vault_password_file%s*=%s*(.+)")
-					if vault_file then
-						if not vault_file:match("^/") then
-							vault_file = project_root .. "/" .. vault_file
-						end
-						if vim.fn.filereadable(vault_file) == 1 then
-							return vault_file
-						end
-					end
-				end
-			else
-				return location
-			end
-		end
-	end
+  for _, location in ipairs(check_locations) do
+    if vim.fn.filereadable(location) == 1 then
+      if vim.fn.fnamemodify(location, ":t") == "ansible.cfg" then
+        local lines = vim.fn.readfile(location)
+        for _, line in ipairs(lines) do
+          local vault_file = line:match("vault_password_file%s*=%s*(.+)")
+          if vault_file then
+            if not vault_file:match("^/") then
+              vault_file = project_root .. "/" .. vault_file
+            end
+            if vim.fn.filereadable(vault_file) == 1 then
+              return vault_file
+            end
+          end
+        end
+      else
+        return location
+      end
+    end
+  end
 
-	if vault_password_files then
-		for _, file in ipairs(vault_password_files) do
-			local vault_path = project_root .. "/" .. file
-			if vim.fn.filereadable(vault_path) == 1 then
-				return vault_path
-			end
-		end
-	end
+  if vault_password_files then
+    for _, file in ipairs(vault_password_files) do
+      local vault_path = project_root .. "/" .. file
+      if vim.fn.filereadable(vault_path) == 1 then
+        return vault_path
+      end
+    end
+  end
 
-	return nil
+  return nil
 end
 
 function M.get_a_line_content(line_num)
-	if not tonumber(line_num) then
-		return nil
-	end
-	return vim.api.nvim_buf_get_text(0, line_num - 1, 0, line_num, 0, {})[1]
+  if not tonumber(line_num) then
+    return nil
+  end
+  return vim.api.nvim_buf_get_text(0, line_num - 1, 0, line_num, 0, {})[1]
 end
 
 function M.is_start_of_value_block(yaml_value)
-	if yaml_value and string.find(yaml_value, "[>|][-]?$") and string.find(yaml_value, "\\") then
-		return true
-	end
-	return false
+  if yaml_value and string.find(yaml_value, "[>|][-]?$") and string.find(yaml_value, "\\") then
+    return true
+  end
+  return false
 end
 
 function M.is_encrypted_value(yaml_value)
-	if yaml_value and string.find(vim.trim(yaml_value), "^!vault") then
-		return true
-	end
-	return false
+  if yaml_value and string.find(vim.trim(yaml_value), "^!vault") then
+    return true
+  end
+  return false
 end
 
 function M.extract_string_pattern(line_num, pattern)
-	if not tonumber(line_num) then
-		return nil
-	end
-	local line_content = M.get_a_line_content(line_num)
-	if not line_content then
-		return nil
-	end
-	local match = string.match(line_content, pattern)
-	return match
+  if not tonumber(line_num) then
+    return nil
+  end
+  local line_content = M.get_a_line_content(line_num)
+  if not line_content then
+    return nil
+  end
+  local match = string.match(line_content, pattern)
+  return match
 end
 
 function M.get_yaml_value_for_the_line(line_num, yaml_key)
-	local line_content = M.get_a_line_content(line_num)
-	if not line_content then
-		return nil
-	end
-	local _, idx_end = string.find(line_content, yaml_key)
-	if not idx_end then
-		return nil
-	end
-	local yaml_value = vim.trim(string.sub(line_content, idx_end + 2))
-	if not yaml_value or string.len(yaml_value) == 0 then
-		return nil
-	end
-	return yaml_value
+  local line_content = M.get_a_line_content(line_num)
+  if not line_content then
+    return nil
+  end
+  local _, idx_end = string.find(line_content, yaml_key)
+  if not idx_end then
+    return nil
+  end
+  local yaml_value = vim.trim(string.sub(line_content, idx_end + 2))
+  if not yaml_value or string.len(yaml_value) == 0 then
+    return nil
+  end
+  return yaml_value
 end
 
 function M.parse_current_line_to_extract_key_and_indent()
-	local current_line_num = vim.fn.line(".")
-	local yaml_key = M.extract_string_pattern(current_line_num, M.pattern_yaml_key)
-	if not yaml_key then
-		vim.notify("Can not read yaml key for the current line", vim.log.levels.WARN)
-		return nil
-	end
-	local line_indent = M.extract_string_pattern(current_line_num, M.pattern_sting_indent) or ""
-	return current_line_num, yaml_key, line_indent
+  local current_line_num = vim.fn.line(".")
+  local yaml_key = M.extract_string_pattern(current_line_num, M.pattern_yaml_key)
+  if not yaml_key then
+    vim.notify("Can not read yaml key for the current line", vim.log.levels.WARN)
+    return nil
+  end
+  local line_indent = M.extract_string_pattern(current_line_num, M.pattern_sting_indent) or ""
+  return current_line_num, yaml_key, line_indent
 end
 
 function M.get_vault_pass_for_current_buffer(vault_password_files)
-	local buf = vim.api.nvim_get_current_buf()
-	local file_path = vim.api.nvim_buf_get_name(buf)
-	if not file_path then
-		return nil
-	end
-	return M.find_vault_pass_file(file_path, vault_password_files)
+  local buf = vim.api.nvim_get_current_buf()
+  local file_path = vim.api.nvim_buf_get_name(buf)
+  if not file_path then
+    return nil
+  end
+  return M.find_vault_pass_file(file_path, vault_password_files)
 end
 
 return M

--- a/lua/ansible-vault/utils.lua
+++ b/lua/ansible-vault/utils.lua
@@ -1,0 +1,141 @@
+local M = {}
+
+M.pattern_yaml_key = "^%s*([a-zA-Z0-9][a-zA-Z0-9_]+):.+$"
+M.pattern_sting_indent = "^(%s).*$"
+M.pattern_hex_line = "^%s*([0-9a-f]+)$"
+
+function M.find_vault_pass_file(path, vault_password_files)
+	if not path then
+		return nil
+	end
+
+	local function find_project_root(start_path)
+		local current_dir = vim.fn.fnamemodify(start_path, ":h")
+		while current_dir ~= "/" do
+			if
+				vim.fn.isdirectory(current_dir .. "/.git") == 1
+				or vim.fn.filereadable(current_dir .. "/ansible.cfg") == 1
+			then
+				return current_dir
+			end
+			current_dir = vim.fn.fnamemodify(current_dir, ":h")
+		end
+		return nil
+	end
+
+	local project_root = find_project_root(path)
+	if not project_root then
+		return nil
+	end
+
+	local check_locations = {
+		project_root .. "/.vault_pass",
+		project_root .. "/vault_pass",
+		project_root .. "/group_vars/.vault_pass",
+		project_root .. "/group_vars/vault_pass",
+		project_root .. "/ansible.cfg",
+	}
+
+	for _, location in ipairs(check_locations) do
+		if vim.fn.filereadable(location) == 1 then
+			if vim.fn.fnamemodify(location, ":t") == "ansible.cfg" then
+				local lines = vim.fn.readfile(location)
+				for _, line in ipairs(lines) do
+					local vault_file = line:match("vault_password_file%s*=%s*(.+)")
+					if vault_file then
+						if not vault_file:match("^/") then
+							vault_file = project_root .. "/" .. vault_file
+						end
+						if vim.fn.filereadable(vault_file) == 1 then
+							return vault_file
+						end
+					end
+				end
+			else
+				return location
+			end
+		end
+	end
+
+	if vault_password_files then
+		for _, file in ipairs(vault_password_files) do
+			local vault_path = project_root .. "/" .. file
+			if vim.fn.filereadable(vault_path) == 1 then
+				return vault_path
+			end
+		end
+	end
+
+	return nil
+end
+
+function M.get_a_line_content(line_num)
+	if not tonumber(line_num) then
+		return nil
+	end
+	return vim.api.nvim_buf_get_text(0, line_num - 1, 0, line_num, 0, {})[1]
+end
+
+function M.is_start_of_value_block(yaml_value)
+	if yaml_value and string.find(yaml_value, "[>|][-]?$") and string.find(yaml_value, "\\") then
+		return true
+	end
+	return false
+end
+
+function M.is_encrypted_value(yaml_value)
+	if yaml_value and string.find(vim.trim(yaml_value), "^!vault") then
+		return true
+	end
+	return false
+end
+
+function M.extract_string_pattern(line_num, pattern)
+	if not tonumber(line_num) then
+		return nil
+	end
+	local line_content = M.get_a_line_content(line_num)
+	if not line_content then
+		return nil
+	end
+	local match = string.match(line_content, pattern)
+	return match
+end
+
+function M.get_yaml_value_for_the_line(line_num, yaml_key)
+	local line_content = M.get_a_line_content(line_num)
+	if not line_content then
+		return nil
+	end
+	local _, idx_end = string.find(line_content, yaml_key)
+	if not idx_end then
+		return nil
+	end
+	local yaml_value = vim.trim(string.sub(line_content, idx_end + 2))
+	if not yaml_value or string.len(yaml_value) == 0 then
+		return nil
+	end
+	return yaml_value
+end
+
+function M.parse_current_line_to_extract_key_and_indent()
+	local current_line_num = vim.fn.line(".")
+	local yaml_key = M.extract_string_pattern(current_line_num, M.pattern_yaml_key)
+	if not yaml_key then
+		vim.notify("Can not read yaml key for the current line", vim.log.levels.WARN)
+		return nil
+	end
+	local line_indent = M.extract_string_pattern(current_line_num, M.pattern_sting_indent) or ""
+	return current_line_num, yaml_key, line_indent
+end
+
+function M.get_vault_pass_for_current_buffer(vault_password_files)
+	local buf = vim.api.nvim_get_current_buf()
+	local file_path = vim.api.nvim_buf_get_name(buf)
+	if not file_path then
+		return nil
+	end
+	return M.find_vault_pass_file(file_path, vault_password_files)
+end
+
+return M


### PR DESCRIPTION
This pull request to add capability to encrypt or decrypt single value in an Ansible YAML file with the command `AnsibleToggleVaultLine`.

Ex execute `AnsibleToggleVaultLine` on clear value line :

Change :

```yaml
my_key: my value
```

into :
```yaml
my_key: !vault |
          $ANSIBLE_VAULT;1.1;AES256
          32643663316162646134366332313461343266646333376461386663663832316431653638326338
          3762366630396130656631323633363537613130633339370a343337306561323831616132323339
          32656430346539663531393630626632316138343536306462333734373839626661656262326430
          3132393833353031310a393830623734616630376636636262616439333265373234636137613633
          6362
```

If you re-execute the command `AnsibleToggleVaultLine` on the same line, you retrieve the clear value.